### PR TITLE
fix: KotlinNativeFlowの中身をFlowを継承したクラスを作るのではなく、Flowをレシーバにする関数を実装するように修正した

### DIFF
--- a/shared/src/commonMain/kotlin/com/coopelife/croissant/util/KotlinNativeFlow.kt
+++ b/shared/src/commonMain/kotlin/com/coopelife/croissant/util/KotlinNativeFlow.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.launch
 /**
 この関数がSwift側のOnCollectというエイリアスに入る
 (typealias OnCollect<Output, Failure> = (@escaping OnEach<Output>, @escaping OnCompletion<Failure>) -> shared.Cancellable)
-の部分と対応している
  */
 fun <T> Flow<T>.collect(onEach: (T) -> Unit, onCompletion: (cause: Throwable?) -> Unit): Cancellable {
     val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)


### PR DESCRIPTION
## :star2: やったこと (必須、1行で簡潔に書く)
FlowWrapperの実装の修正

## :mag_right: 詳細 (必須)


## :bug: 確認したこと (必須)


## :memo: 関連リンク


## :art: UI 差分
|BEFORE|AFTER|
|:--:|:--:|
|<img width="300" src=""/>|<img width="300" src=""/>|
