### PR TITLE
日付選択用のラジオボタンの実装

### DIFF
--- a/androidApp/src/main/java/com/coopelife/croissant/android/Content.kt
+++ b/androidApp/src/main/java/com/coopelife/croissant/android/Content.kt
@@ -48,8 +48,8 @@ fun Content() {
                     val navBackStackEntry by navController.currentBackStackEntryAsState()
                     val currentRoute = navBackStackEntry?.destination?.route
                     screenItems.forEach { screen ->
-                        val route: String = stringResource(id = screen.routeStrResId)
-                        val title: String = stringResource(id = screen.titleStrResId)
+                        val route: String = stringResource(screen.routeStrResId)
+                        val title: String = stringResource(screen.titleStrResId)
                         val isSelected: Boolean = currentRoute == route
                         BottomNavigationItem(
                             icon = {
@@ -76,7 +76,7 @@ fun Content() {
                 }
             }
         ) {
-            NavHost(navController, startDestination = stringResource(id = R.string.home_route)) {
+            NavHost(navController, startDestination = stringResource(R.string.home_route)) {
                 // TODO: ハードコーディングの解消
                 composable("home") { HomeScreen(nacController = navController) }
                 composable("mypage") { MypageScreen(navController = navController) }

--- a/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectChipGroup.kt
+++ b/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectChipGroup.kt
@@ -1,0 +1,7 @@
+package com.coopelife.croissant.android.ui.component.home
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun DataSelectChipGroup() {
+}

--- a/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectRadioGroup.kt
+++ b/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectRadioGroup.kt
@@ -3,5 +3,5 @@ package com.coopelife.croissant.android.ui.component.home
 import androidx.compose.runtime.Composable
 
 @Composable
-fun DataSelectChipGroup() {
+fun DataSelectRadioGroup() {
 }

--- a/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectRadioGroup.kt
+++ b/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectRadioGroup.kt
@@ -1,29 +1,84 @@
 package com.coopelife.croissant.android.ui.component.home
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.coopelife.croissant.android.ui.util.theme.Orange
 
 @Composable
 fun DateSelectRadioGroup() {
 }
 
 @Composable
-fun DateSelectRadioButton() {
-    Box(
-        modifier = Modifier
-            .size(100.dp)
-            .clip(shape = CircleShape)
-    )
+fun DateSelectRadioButton(
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    dateText: String,
+) {
+    if (isSelected)
+        Box(
+            modifier = Modifier
+                .size(100.dp)
+                .clip(shape = CircleShape)
+                .clickable { onClick() }
+                .background(Orange),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = dateText,
+                color = Color.White,
+                style = MaterialTheme.typography.h4,
+                textAlign = TextAlign.Center,
+            )
+        }
+    else
+        Box(
+            modifier = Modifier
+                .size(80.dp)
+                .clip(shape = CircleShape)
+                .clickable { onClick() }
+                .border(
+                    width = 4.dp,
+                    color = Orange,
+                    shape = RoundedCornerShape(40.dp)
+                )
+                .background(
+                    color = Color.White,
+                    shape = RoundedCornerShape(40.dp)
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = dateText,
+                color = Color.Black,
+                style = MaterialTheme.typography.h5,
+                textAlign = TextAlign.Center,
+            )
+        }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun Preview() {
-    DateSelectRadioButton()
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        DateSelectRadioButton(isSelected = true, dateText = "5/28", onClick = {})
+        DateSelectRadioButton(isSelected = false, dateText = "5/29", onClick = {})
+    }
 }

--- a/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectRadioGroup.kt
+++ b/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectRadioGroup.kt
@@ -1,7 +1,29 @@
 package com.coopelife.croissant.android.ui.component.home
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 
 @Composable
-fun DataSelectRadioGroup() {
+fun DateSelectRadioGroup() {
+}
+
+@Composable
+fun DateSelectRadioButton() {
+    Box(
+        modifier = Modifier
+            .size(100.dp)
+            .clip(shape = CircleShape)
+    )
+}
+
+@Preview
+@Composable
+fun Preview() {
+    DateSelectRadioButton()
 }

--- a/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectRadioGroup.kt
+++ b/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectRadioGroup.kt
@@ -15,9 +15,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
+import com.coopelife.croissant.android.R
 import com.coopelife.croissant.android.ui.util.theme.Orange
 
 @Composable
@@ -25,7 +26,7 @@ fun DateSelectRadioGroup() {
 }
 
 @Composable
-fun DateSelectRadioButton(
+private fun DateSelectRadioButton(
     isSelected: Boolean,
     onClick: () -> Unit,
     dateText: String,
@@ -33,12 +34,12 @@ fun DateSelectRadioButton(
     if (isSelected)
         Box(
             modifier = Modifier
-                .size(100.dp)
+                .size(dimensionResource(R.dimen.selected_size))
                 .clip(shape = CircleShape)
                 .clickable { onClick() }
                 .background(
                     color = Orange,
-                    shape = RoundedCornerShape(50.dp)
+                    shape = RoundedCornerShape(dimensionResource(R.dimen.selected_corner_radius))
                 ),
             contentAlignment = Alignment.Center,
         ) {
@@ -52,17 +53,17 @@ fun DateSelectRadioButton(
     else
         Box(
             modifier = Modifier
-                .size(80.dp)
+                .size(dimensionResource(R.dimen.not_selected_size))
                 .clip(shape = CircleShape)
                 .clickable { onClick() }
                 .border(
-                    width = 4.dp,
+                    width = dimensionResource(R.dimen.not_selected_border_width),
                     color = Orange,
-                    shape = RoundedCornerShape(40.dp)
+                    shape = RoundedCornerShape(dimensionResource(R.dimen.not_selected_corner_radius))
                 )
                 .background(
                     color = Color.White,
-                    shape = RoundedCornerShape(40.dp)
+                    shape = RoundedCornerShape(dimensionResource(R.dimen.not_selected_corner_radius))
                 ),
             contentAlignment = Alignment.Center,
         ) {

--- a/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectRadioGroup.kt
+++ b/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectRadioGroup.kt
@@ -26,17 +26,18 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.coopelife.croissant.android.R
+import com.coopelife.croissant.android.ui.util.extension.fontDimensionResource
 import com.coopelife.croissant.android.ui.util.theme.Orange
 
 @Composable
-fun DateSelectRadioGroup() {
+fun DateSelectRadioGroup(modifier: Modifier = Modifier) {
     val dateList: List<String> = listOf("12/28", "12/29", "12/30", "12/31", "1/1")
     var selectedIndex: Int by remember { mutableStateOf(0) }
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceEvenly,
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
     ) {
         for (i in 0 until dateList.size) {
             DateSelectRadioButton(
@@ -70,7 +71,9 @@ private fun DateSelectRadioButton(
             Text(
                 text = dateText,
                 color = Color.White,
-                style = MaterialTheme.typography.h6,
+                style = MaterialTheme.typography.h5.copy(
+                    fontSize = fontDimensionResource(R.dimen.selected_font_size)
+                ),
                 textAlign = TextAlign.Center,
             )
         }
@@ -95,7 +98,9 @@ private fun DateSelectRadioButton(
             Text(
                 text = dateText,
                 color = Orange,
-                style = MaterialTheme.typography.subtitle1,
+                style = MaterialTheme.typography.h6.copy(
+                    fontSize = fontDimensionResource(R.dimen.not_selected_font_size)
+                ),
                 textAlign = TextAlign.Center,
             )
         }

--- a/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectRadioGroup.kt
+++ b/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectRadioGroup.kt
@@ -3,14 +3,21 @@ package com.coopelife.croissant.android.ui.component.home
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -23,6 +30,22 @@ import com.coopelife.croissant.android.ui.util.theme.Orange
 
 @Composable
 fun DateSelectRadioGroup() {
+    val dateList: List<String> = listOf("12/28", "12/29", "12/30", "12/31", "1/1")
+    var selectedIndex: Int by remember { mutableStateOf(0) }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        for (i in 0 until dateList.size) {
+            DateSelectRadioButton(
+                isSelected = i == selectedIndex,
+                onClick = { selectedIndex = i },
+                dateText = dateList[i]
+            )
+        }
+    }
 }
 
 @Composable
@@ -40,13 +63,14 @@ private fun DateSelectRadioButton(
                 .background(
                     color = Orange,
                     shape = RoundedCornerShape(dimensionResource(R.dimen.selected_corner_radius))
-                ),
+                )
+                .padding(dimensionResource(R.dimen.padding_4dp)),
             contentAlignment = Alignment.Center,
         ) {
             Text(
                 text = dateText,
                 color = Color.White,
-                style = MaterialTheme.typography.h4,
+                style = MaterialTheme.typography.h6,
                 textAlign = TextAlign.Center,
             )
         }
@@ -64,13 +88,14 @@ private fun DateSelectRadioButton(
                 .background(
                     color = Color.White,
                     shape = RoundedCornerShape(dimensionResource(R.dimen.not_selected_corner_radius))
-                ),
+                )
+                .padding(dimensionResource(R.dimen.padding_4dp)),
             contentAlignment = Alignment.Center,
         ) {
             Text(
                 text = dateText,
                 color = Orange,
-                style = MaterialTheme.typography.h5,
+                style = MaterialTheme.typography.subtitle1,
                 textAlign = TextAlign.Center,
             )
         }
@@ -79,10 +104,5 @@ private fun DateSelectRadioButton(
 @Preview(showBackground = true)
 @Composable
 fun Preview() {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        DateSelectRadioButton(isSelected = true, dateText = "5/28", onClick = {})
-        DateSelectRadioButton(isSelected = false, dateText = "5/29", onClick = {})
-    }
+    DateSelectRadioGroup()
 }

--- a/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectRadioGroup.kt
+++ b/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectRadioGroup.kt
@@ -65,7 +65,7 @@ fun DateSelectRadioButton(
         ) {
             Text(
                 text = dateText,
-                color = Color.Black,
+                color = Orange,
                 style = MaterialTheme.typography.h5,
                 textAlign = TextAlign.Center,
             )

--- a/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectRadioGroup.kt
+++ b/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectRadioGroup.kt
@@ -36,7 +36,10 @@ fun DateSelectRadioButton(
                 .size(100.dp)
                 .clip(shape = CircleShape)
                 .clickable { onClick() }
-                .background(Orange),
+                .background(
+                    color = Orange,
+                    shape = RoundedCornerShape(50.dp)
+                ),
             contentAlignment = Alignment.Center,
         ) {
             Text(

--- a/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectRadioGroup.kt
+++ b/androidApp/src/main/java/com/coopelife/croissant/android/ui/component/home/DateSelectRadioGroup.kt
@@ -16,7 +16,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -32,7 +32,7 @@ import com.coopelife.croissant.android.ui.util.theme.Orange
 @Composable
 fun DateSelectRadioGroup(modifier: Modifier = Modifier) {
     val dateList: List<String> = listOf("12/28", "12/29", "12/30", "12/31", "1/1")
-    var selectedIndex: Int by remember { mutableStateOf(0) }
+    var selectedIndex: Int by rememberSaveable { mutableStateOf(0) }
 
     Row(
         verticalAlignment = Alignment.CenterVertically,

--- a/androidApp/src/main/java/com/coopelife/croissant/android/ui/screen/home/HomeScreen.kt
+++ b/androidApp/src/main/java/com/coopelife/croissant/android/ui/screen/home/HomeScreen.kt
@@ -2,9 +2,6 @@ package com.coopelife.croissant.android.ui.screen.home
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Button
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -13,6 +10,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.coopelife.croissant.android.R
+import com.coopelife.croissant.android.ui.component.home.DateSelectRadioGroup
 
 @Composable
 fun HomeScreen(
@@ -27,16 +25,6 @@ fun HomeScreen(
 @Composable
 private fun HomeContent(screenName: String, onClick: () -> Unit) {
     Column(modifier = Modifier.padding(dimensionResource(R.dimen.padding_16dp))) {
-        Text(
-            text = screenName,
-            modifier = Modifier.padding(bottom = dimensionResource(R.dimen.padding_8dp)),
-            style = MaterialTheme.typography.h3
-        )
-        Button(onClick = onClick) {
-            Text(
-                text = "Click me!",
-                modifier = Modifier.padding(dimensionResource(R.dimen.padding_4dp))
-            )
-        }
+        DateSelectRadioGroup()
     }
 }

--- a/androidApp/src/main/java/com/coopelife/croissant/android/ui/screen/home/HomeScreen.kt
+++ b/androidApp/src/main/java/com/coopelife/croissant/android/ui/screen/home/HomeScreen.kt
@@ -26,16 +26,16 @@ fun HomeScreen(
 
 @Composable
 private fun HomeContent(screenName: String, onClick: () -> Unit) {
-    Column(modifier = Modifier.padding(dimensionResource(id = R.dimen.padding_16dp))) {
+    Column(modifier = Modifier.padding(dimensionResource(R.dimen.padding_16dp))) {
         Text(
             text = screenName,
-            modifier = Modifier.padding(bottom = dimensionResource(id = R.dimen.padding_8dp)),
+            modifier = Modifier.padding(bottom = dimensionResource(R.dimen.padding_8dp)),
             style = MaterialTheme.typography.h3
         )
         Button(onClick = onClick) {
             Text(
                 text = "Click me!",
-                modifier = Modifier.padding(dimensionResource(id = R.dimen.padding_4dp))
+                modifier = Modifier.padding(dimensionResource(R.dimen.padding_4dp))
             )
         }
     }

--- a/androidApp/src/main/java/com/coopelife/croissant/android/ui/screen/home/HomeScreen.kt
+++ b/androidApp/src/main/java/com/coopelife/croissant/android/ui/screen/home/HomeScreen.kt
@@ -24,7 +24,7 @@ fun HomeScreen(
 
 @Composable
 private fun HomeContent(screenName: String, onClick: () -> Unit) {
-    Column(modifier = Modifier.padding(dimensionResource(R.dimen.padding_16dp))) {
-        DateSelectRadioGroup()
+    Column {
+        DateSelectRadioGroup(Modifier.padding(top = dimensionResource(R.dimen.padding_16dp)))
     }
 }

--- a/androidApp/src/main/java/com/coopelife/croissant/android/ui/screen/mypage/MypageScreen.kt
+++ b/androidApp/src/main/java/com/coopelife/croissant/android/ui/screen/mypage/MypageScreen.kt
@@ -26,10 +26,10 @@ fun MypageScreen(
 
 @Composable
 fun MypageContent(previewText: String, onValueChanged: (String) -> Unit) {
-    Column(modifier = Modifier.padding(dimensionResource(id = R.dimen.padding_16dp))) {
+    Column(modifier = Modifier.padding(dimensionResource(R.dimen.padding_16dp))) {
         Text(
             text = previewText,
-            modifier = Modifier.padding(bottom = dimensionResource(id = R.dimen.padding_8dp)),
+            modifier = Modifier.padding(bottom = dimensionResource(R.dimen.padding_8dp)),
             style = MaterialTheme.typography.h3
         )
         OutlinedTextField(

--- a/androidApp/src/main/java/com/coopelife/croissant/android/ui/util/extension/fontDimensionResource.kt
+++ b/androidApp/src/main/java/com/coopelife/croissant/android/ui/util/extension/fontDimensionResource.kt
@@ -1,0 +1,12 @@
+package com.coopelife.croissant.android.ui.util.extension
+
+import androidx.annotation.DimenRes
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+
+@Composable
+@ReadOnlyComposable
+fun fontDimensionResource(@DimenRes id: Int): TextUnit = dimensionResource(id = id).value.sp

--- a/androidApp/src/main/res/values/dimens.xml
+++ b/androidApp/src/main/res/values/dimens.xml
@@ -8,7 +8,9 @@
     <!-- DateSelectRadioButton -->
     <dimen name="selected_size">72dp</dimen>
     <dimen name="selected_corner_radius">36dp</dimen>
+    <dimen name="selected_font_size">20sp</dimen>
     <dimen name="not_selected_size">56dp</dimen>
     <dimen name="not_selected_corner_radius">28dp</dimen>
+    <dimen name="not_selected_font_size">14sp</dimen>
     <dimen name="not_selected_border_width">2dp</dimen>
 </resources>

--- a/androidApp/src/main/res/values/dimens.xml
+++ b/androidApp/src/main/res/values/dimens.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- padding -->
     <dimen name="padding_4dp">4dp</dimen>
     <dimen name="padding_8dp">8dp</dimen>
     <dimen name="padding_16dp">16dp</dimen>
+
+    <!-- DateSelectRadioButton -->
+    <dimen name="selected_size">100dp</dimen>
+    <dimen name="selected_corner_radius">50dp</dimen>
+    <dimen name="not_selected_size">80dp</dimen>
+    <dimen name="not_selected_corner_radius">40dp</dimen>
+    <dimen name="not_selected_border_width">4dp</dimen>
 </resources>

--- a/androidApp/src/main/res/values/dimens.xml
+++ b/androidApp/src/main/res/values/dimens.xml
@@ -6,9 +6,9 @@
     <dimen name="padding_16dp">16dp</dimen>
 
     <!-- DateSelectRadioButton -->
-    <dimen name="selected_size">100dp</dimen>
-    <dimen name="selected_corner_radius">50dp</dimen>
-    <dimen name="not_selected_size">80dp</dimen>
-    <dimen name="not_selected_corner_radius">40dp</dimen>
-    <dimen name="not_selected_border_width">4dp</dimen>
+    <dimen name="selected_size">72dp</dimen>
+    <dimen name="selected_corner_radius">36dp</dimen>
+    <dimen name="not_selected_size">56dp</dimen>
+    <dimen name="not_selected_corner_radius">28dp</dimen>
+    <dimen name="not_selected_border_width">2dp</dimen>
 </resources>


### PR DESCRIPTION
## :star2: やったこと (必須、1行で簡潔に書く)
日付選択用のラジオボタンの実装

## :mag_right: 詳細 (必須)
- [x] 日付選択用のラジオボタンの実装
- [x] fontSize を dimens.xml から取得できるメソッドの実装
- [x] ラジオボタンを HomeScreen で表示

## :bug: 確認したこと (必須)

## :memo: 関連リンク
- [Create a ChipGroup with Jetpack Compose](https://medium.com/@Rieger_san/create-a-chipgroup-with-jetpack-compose-f4744b94fa34)
- [Jetpack Compose: RadioButton](https://alexzh.com/jetpack-compose-radio-button/)
- [CircleShape - Jetpack Compose Playground](https://foso.github.io/Jetpack-Compose-Playground/foundation/shape/#circleshape)
- [その他のリソースタイプ](https://developer.android.com/guide/topics/resources/more-resources?hl=ja#Dimension)
- [[Text Composable dimensionResource not working as fontSize parameter](https://stackoverflow.com/questions/67522145/text-composable-dimensionresource-not-working-as-fontsize-parameter)](https://stackoverflow.com/questions/67522145/text-composable-dimensionresource-not-working-as-fontsize-parameter)
- [Compose レイアウトの基本](https://developer.android.com/jetpack/compose/layouts/basics?hl=ja)
- [【Jetpack Compose】適当に引数にModifierを渡していない？](https://zenn.dev/ho2ri2s/articles/d0939ffefb21bb)

## :art: UI 差分
|BEFORE|AFTER|
|:--:|:--:|
|<img width="300" src=""/>|<img width="300" src="https://user-images.githubusercontent.com/49048577/171028426-5fdc13d4-6159-463d-9050-b5b38dd645f4.png"/>|
